### PR TITLE
[CRI-115] Add People section to Home Page

### DIFF
--- a/code_review_interview/backend/models.py
+++ b/code_review_interview/backend/models.py
@@ -10,6 +10,9 @@ class Person(models.Model):
 
     name = models.CharField(max_length=64)
 
+    # FRONTEND / BACKEND / FULLSTACK / INFRA
+    engineer_type = models.CharField(max_length=64, blank=True, null=True)
+
 
 class JiraIssue(models.Model):
 

--- a/code_review_interview/backend/views.py
+++ b/code_review_interview/backend/views.py
@@ -1,6 +1,7 @@
 
 from code_review_interview.backend.models import Team, Person, JiraIssue
 from rest_framework import generics, serializers
+from rest_framework.response import Response
 
 
 class TeamSerializer(serializers.ModelSerializer):
@@ -32,3 +33,76 @@ class GetJiraIssuesView(generics.ListAPIView):
 
     def get_queryset(self):
         return JiraIssue.objects.all().select_related('team')
+    
+
+class EngineerTypeSerializer(serializers.Serializer):
+    key = serializers.CharField()
+    label = serializers.CharField()
+    color = serializers.CharField()
+    
+
+class PersonSerializer(serializers.ModelSerializer):
+    team = TeamSerializer(allow_null=True)
+    engineer_type = EngineerTypeSerializer(source="engineer_type_data")
+
+    class Meta:
+        model = Person
+        fields = [
+            'id',
+            'name',
+            'team',
+            'engineer_type',
+        ]
+    
+
+class GetPeopleView(generics.ListAPIView):
+    serializer_class = PersonSerializer
+
+    def get(self):
+        people = Person.objects.all()
+
+        if not people.exists():
+            return Response(status=404)
+
+        for person in people:
+            issue_count_by_team = {}
+            for issue in person.assigned_jira_issues.all():
+                team_id = issue.team.id
+                if team_id not in issue_count_by_team:
+                    issue_count_by_team[team_id] = 0
+                issue_count_by_team[team_id] += 1
+
+            max_issue_count = 0
+            allocated_team_id = None
+            for team_id, issue_count in issue_count_by_team.items():
+                if issue_count > max_issue_count:
+                    max_issue_count = issue_count
+                    allocated_team_id = team_id
+            
+            if allocated_team_id:
+                person.team = Team.objects.get(id=allocated_team_id)
+
+            if person.engineer_type == 'FRONTEND':
+                engineer_type_label = 'Frontend'
+                engineer_type_color = "#0f73ff"
+            elif person.engineer_type == 'BACKEND':
+                engineer_type_label = 'Backend'
+                engineer_type_color = "#ff6b0f"
+            elif person.engineer_type == 'FULLSTACK':
+                engineer_type_label = 'Fullstack'
+                engineer_type_color = "#4dd826"
+            elif person.engineer_type == 'INFRA':
+                engineer_type_label = 'Infrastructure'
+                engineer_type_color = "#ffcb0f"
+            else:
+                engineer_type_label = 'Non-Engineer'
+                engineer_type_color = "#8d8d8d"
+
+            person.engineer_type_data = {
+                "key": person.engineer_type or "NONE",
+                "label": engineer_type_label,
+                "color": engineer_type_color
+            }
+
+        serialized_data = self.serializer_class(people, many=True).data
+        return Response(serialized_data)

--- a/code_review_interview/frontend/HomePage.tsx
+++ b/code_review_interview/frontend/HomePage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useQuery } from 'react-query';
 
 import { IssueList } from './IssueList';
+import { PeopleList } from './PeopleList';
 import { Issue } from './types';
 
 export const HomePage: React.FC = () => {
@@ -11,10 +12,19 @@ export const HomePage: React.FC = () => {
     { staleTime: 1_200_000 }
   );
 
+  const { data: people } = useQuery(
+    ['GET_PEOPLE'],
+    () => fetch('/people', { method: 'GET' }).then((response) => response.json()),
+    { staleTime: 1_200_000 }
+  );
+
   return (
     <div>
       <h1>Issues</h1>
       <IssueList issues={issues} />
+
+      <h1>People</h1>
+      <PeopleList people={people} />
     </div>
   );
 };

--- a/code_review_interview/frontend/PeopleList.tsx
+++ b/code_review_interview/frontend/PeopleList.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+
+import { PeopleListCard } from './PeopleListCard';
+
+type PeopleListProps = {
+  people: any;
+};
+
+export const PeopleList: React.FC<PeopleListProps> = (props) => {
+  useEffect(() => {
+    props.people.sort((a, b) => a.name.localeCompare(b.name));
+  }, [props.people]);
+
+  if (!props.people) {
+    return 'Loading...';
+  }
+
+  return (
+    <div>
+      {props.people.map((person) => (
+        <PeopleListCard key={person.name} person={person} />
+      ))}
+    </div>
+  );
+};

--- a/code_review_interview/frontend/PeopleListCard.tsx
+++ b/code_review_interview/frontend/PeopleListCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type PeopleListCardProps = {
+  person: any;
+};
+
+export const PeopleListCard: React.FC<PeopleListCardProps> = (props) => {
+  const navigate = useNavigate();
+
+  return (
+    <div style={{ marginTop: '24px' }} onClick={() => navigate(`/person/${props.person.id}`)}>
+      <div>{props.person.name}</div>
+      <div>Team: {props.person.team?.name}</div>
+      <div style={{ backgroundColor: props.person.engineerType.color, color: 'white' }}>
+        {props.person.engineerType.label}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
### Changes
- Added endpoint to get people
- Added list of people to home page


### Testing
- [x] Validated on local machine ✅ 


<br>
<details>
<summary>Jira Ticket</summary>

## Description
We want to add a new "People" section to the Home page. This section should display a card for each person, with what team they are on and what type of engineer they are. You should be able to click the cards to go to the Person page. Let's also sort the people by name.

### Team
A person doesn't directly have a linked team. We will have to look at their assigned Jira issues to see what team they have done the most work for.

### Engineer Type
For a person's engineer type, we will have to add a new field in the database. This value can be `FRONTEND`, `BACKEND`, `FULLSTACK`, or `INFRA`. If it's null, we can assume that person is not an engineer.

<img width="300" alt="Screenshot 2025-09-12 at 9 14 48 AM" src="https://github.com/user-attachments/assets/b693b4cd-2427-4c4c-8d42-123293857e7c" />
</details>
